### PR TITLE
Can handle template function from text table now

### DIFF
--- a/src/fndescr.c
+++ b/src/fndescr.c
@@ -97,7 +97,7 @@ init_fndescr(pid_t pid)
 
                 for (i = 0; i < er->nsymbols; i++) {
                     const elf_symbol_t *es = &er->symbols[i];
-                    if (es->symbol_class == 'T')
+                    if (es->symbol_class == 'T' || es->symbol_class == 'W')
                         add_fndescr(es->symbol_name, es->symbol_value, es->symbol_size);
                 }
                 elfreader_close(er);


### PR DESCRIPTION
Some C++ functions have 'W' symbol class, so they don't get in profile statistic list.
Looks like we should take into account such functions from text table too (not only from dynamic table), to get a more correct statistics. Unless, throw out such functions was not an original idea.
